### PR TITLE
ops: test ansible for host configuration

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,6 @@
+# Ansible configuration for FCEFyN testbed playbooks.
+# Run from repo root: ansible-playbook -i ansible/inventory/hosts.yml ansible/playbook_testbed.yml
+
+[defaults]
+roles_path = ./ansible/roles
+inventory = ./ansible/inventory/hosts.yml

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -1,0 +1,12 @@
+# Inventory for FCEFyN testbed orchestration host.
+# Run playbook_testbed.yml against localhost (host where Ansible executes).
+#
+# Usage:
+#   ansible-playbook -i ansible/inventory/hosts.yml ansible/playbook_testbed.yml
+#   ansible-playbook -i ansible/inventory/hosts.yml ansible/playbook_testbed.yml --tags virtual_mesh
+#   ansible-playbook -i ansible/inventory/hosts.yml ansible/playbook_testbed.yml --tags arduino
+
+all:
+  hosts:
+    localhost:
+      ansible_connection: local

--- a/ansible/playbook_testbed.yml
+++ b/ansible/playbook_testbed.yml
@@ -1,0 +1,28 @@
+---
+# Playbook: FCEFyN testbed infrastructure.
+#
+# Installs components NOT covered by openwrt-tests/libremesh-tests playbook_labgrid.yml:
+#   - virtual_mesh: vwifi-server, QEMU, mac80211_hwsim (for virtual mesh tests)
+#   - arduino: arduino-relay-daemon, udev rules (for physical DUT power control)
+#
+# Run AFTER or BEFORE playbook_labgrid.yml from fork-openwrt-tests.
+#
+# Usage (from repo root):
+#   pipx run --spec ansible-core ansible-playbook -i ansible/inventory/hosts.yml ansible/playbook_testbed.yml --ask-become-pass
+#   pipx run --spec ansible-core ansible-playbook -i ansible/inventory/hosts.yml ansible/playbook_testbed.yml --tags virtual_mesh --ask-become-pass
+#   pipx run --spec ansible-core ansible-playbook -i ansible/inventory/hosts.yml ansible/playbook_testbed.yml --tags arduino --ask-become-pass
+#
+# Or if ansible-core is installed: ansible-playbook -i ansible/inventory/hosts.yml ansible/playbook_testbed.yml -K
+
+- name: FCEFyN testbed infrastructure
+  hosts: localhost
+  become: true
+  roles:
+    - role: virtual_mesh
+      tags:
+        - virtual_mesh
+        - testbed
+    - role: arduino_relay
+      tags:
+        - arduino
+        - testbed

--- a/ansible/roles/arduino_relay/tasks/main.yml
+++ b/ansible/roles/arduino_relay/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+# Role: arduino_relay
+# Installs arduino-relay-daemon and udev rules for DUT power control via Arduino relays.
+# Requires: udev rules create /dev/arduino-relay when Arduino is connected.
+
+- name: Install Python dependencies for arduino daemon
+  ansible.builtin.apt:
+    name:
+      - python3-serial
+    state: present
+    update_cache: yes
+
+- name: Copy arduino_daemon.py to /usr/local/bin
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../scripts/arduino/arduino_daemon.py"
+    dest: /usr/local/bin/arduino_daemon.py
+    mode: "0755"
+
+- name: Copy udev rules for serial devices
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../configs/templates/99-serial-devices.rules"
+    dest: /etc/udev/rules.d/99-serial-devices.rules
+    mode: "0644"
+
+- name: Copy arduino-relay-daemon systemd unit
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../configs/templates/arduino-relay-daemon.service"
+    dest: /etc/systemd/system/arduino-relay-daemon.service
+    mode: "0644"
+
+- name: Reload udev rules
+  ansible.builtin.command: udevadm control --reload-rules
+  changed_when: true
+
+- name: Trigger udev
+  ansible.builtin.command: udevadm trigger
+  changed_when: true
+
+- name: Reload systemd daemon
+  ansible.builtin.systemd:
+    daemon_reload: yes
+
+- name: Enable arduino-relay-daemon service
+  ansible.builtin.systemd:
+    name: arduino-relay-daemon
+    enabled: yes
+    state: started

--- a/ansible/roles/virtual_mesh/tasks/main.yml
+++ b/ansible/roles/virtual_mesh/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+# Role: virtual_mesh
+# Installs vwifi-server, QEMU, and mac80211_hwsim for virtual mesh tests (QEMU + vwifi).
+
+- name: Install apt packages for virtual mesh
+  ansible.builtin.apt:
+    name:
+      - qemu-system-x86
+      - cmake
+      - build-essential
+      - git
+      - libnl-3-dev
+      - libnl-genl-3-dev
+      - pkg-config
+    state: present
+    update_cache: yes
+
+- name: Ensure vwifi build directory exists
+  ansible.builtin.file:
+    path: /tmp/vwifi-build
+    state: directory
+    mode: "0755"
+
+- name: Clone vwifi repository
+  ansible.builtin.git:
+    repo: https://github.com/Raizo62/vwifi.git
+    dest: /tmp/vwifi-build/vwifi
+    version: master
+    force: yes
+
+- name: Create vwifi build directory
+  ansible.builtin.file:
+    path: /tmp/vwifi-build/vwifi/build
+    state: directory
+    mode: "0755"
+
+- name: Configure vwifi with cmake
+  ansible.builtin.command:
+    cmd: cmake ..
+    chdir: /tmp/vwifi-build/vwifi/build
+
+- name: Build vwifi
+  ansible.builtin.command:
+    cmd: make -j{{ ansible_processor_vcpus | default(4) }}
+    chdir: /tmp/vwifi-build/vwifi/build
+
+- name: Install vwifi binaries
+  ansible.builtin.command:
+    cmd: make install
+    chdir: /tmp/vwifi-build/vwifi/build
+
+- name: Ensure mac80211_hwsim is loaded at boot
+  ansible.builtin.copy:
+    dest: /etc/modules-load.d/mac80211_hwsim.conf
+    content: |
+      # Loaded by Ansible (virtual_mesh role) for vwifi virtual mesh tests
+      mac80211_hwsim
+    mode: "0644"
+
+- name: Load mac80211_hwsim kernel module
+  ansible.builtin.command:
+    cmd: modprobe mac80211_hwsim
+  changed_when: true
+
+- name: Verify vwifi-server is installed
+  ansible.builtin.command: which vwifi-server
+  register: vwifi_which
+  changed_when: false
+  failed_when: vwifi_which.rc != 0
+
+- name: Verify qemu-system-x86_64 is installed
+  ansible.builtin.command: which qemu-system-x86_64
+  register: qemu_which
+  changed_when: false
+  failed_when: qemu_which.rc != 0


### PR DESCRIPTION
ansible playbook for deploying host-level services required in the testbed host wich can not be deployed using openwrt-tests or libremesh-tests playbooks since are only valid for our custom infrastructure. 