### PR TITLE
docs: add LibreMesh CI/CD demo video

### DIFF
--- a/docs/demos.md
+++ b/docs/demos.md
@@ -41,3 +41,40 @@ In this demo we show the process that a LibreMesh or OpenWrt developer should fo
 </div>
 
 ---
+
+## LibreMesh CI/CD — from pull request to physical hardware
+
+This demo shows the end-to-end CI/CD workflow for the
+[libremesh-tests](https://github.com/fcefyn-testbed/libremesh-tests) repository,
+illustrating how changes are validated automatically at two levels before and after merging.
+
+**When a pull request is opened**, the `Pull Requests` workflow triggers and runs the test
+suite in parallel against three QEMU virtual machine targets:
+
+- `malta-be` — MIPS big-endian, emulated with `qemu-system-mips`
+- `x86-64` — x86 64-bit, emulated with `qemu-system-x86`
+- `armsr-armv8` — AArch64, emulated with `qemu-system-aarch64`
+
+This provides fast, architecture-wide feedback on every proposed change without requiring
+access to physical hardware.
+
+**Once the pull request is approved and merged into `main`**, the `Daily test` workflow runs
+the same test suite against the **physical devices** in the HIL testbed, managed remotely via
+[Labgrid](https://labgrid.readthedocs.io). Devices are reserved, flashed over the network,
+tested, and released automatically. Results are published to the testbed's CI dashboard on
+GitHub Pages.
+
+**Watch on YouTube:** [Demo LibreMesh CI/CD Workflow](https://www.youtube.com/watch?v=P8dggBEgez8)
+
+<div class="video-embed">
+  <iframe
+    src="https://www.youtube.com/embed/P8dggBEgez8"
+    title="Demo LibreMesh CI/CD — from pull request to physical hardware"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+    loading="lazy"
+    referrerpolicy="strict-origin-when-cross-origin"
+  ></iframe>
+</div>
+
+---

--- a/docs/operar/build-firmware-manual.md
+++ b/docs/operar/build-firmware-manual.md
@@ -192,3 +192,5 @@ For architecture, caching, and feed indexing details, see:
 - [lime-packages CI: hardware tests](../diseno/lime-packages-test-flow.md) (downstream **libremesh-tests** on the `testbed-fcefyn` self-hosted runner)
 
 Manual procedures above still apply when you build outside CI or need a custom `menuconfig` / full Buildroot tree.
+
+For the automated CI workflow that builds and tests firmware directly in this repo, see [CI: Build & Test](ci-build-and-test.md).

--- a/docs/operar/ci-build-and-test.md
+++ b/docs/operar/ci-build-and-test.md
@@ -1,0 +1,167 @@
+# CI: Build & Test LibreMesh
+
+This workflow builds a LibreMesh firmware image from source and runs automated
+tests on a physical device in the FCEFYN lab.
+
+It is triggered **manually** — it does not run automatically on every commit.
+You decide when to run it and with which parameters.
+
+---
+
+## When to use it
+
+Run this workflow when you want to:
+
+- Test a specific version or branch of
+  [lime-packages](https://github.com/libremesh/lime-packages) on real hardware
+- Verify that a set of packages installs and boots correctly on a lab device
+- Produce a firmware image with custom packages for a specific device
+
+---
+
+## How to run it
+
+1. Go to the repository on GitHub
+2. Click the **Actions** tab
+3. Select **Build LibreMesh and Test on DUT** in the left panel
+4. Click **Run workflow**
+5. Fill in the inputs (see below) and click the green **Run workflow** button
+
+---
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `duts` | yes | `belkin_rt3200` | Device(s) to build and test. Comma-separated. Use `all` for every lab device. |
+| `lime_ref` | yes | `v2024.1` | Branch, tag, or commit SHA of lime-packages to build from. |
+| `openwrt_version` | no | `23.05.5` | OpenWrt version to use. Must be compatible with `lime_ref`. |
+| `extra_packages` | no | _(empty)_ | Space-separated packages to add or remove from the base set. Prefix with `-` to remove. Example: `luci-app-dawn -lime-proto-batadv` |
+| `config_file` | no | _(empty)_ | Repo-relative path to a config file to inject as `/etc/config/<name>` in the firmware. Example: `firmware/configs/belkin_rt3200.conf` |
+
+### Supported devices
+
+| `duts` value | Hardware | OpenWrt target |
+|---|---|---|
+| `belkin_rt3200` | Belkin RT3200 / Linksys E8450 | `mediatek/mt7622` |
+| `openwrt_one` | OpenWrt One | `mediatek/filogic` |
+| `bananapi_r4` | Banana Pi R4 | `mediatek/filogic` |
+| `librerouter` | LibreRouter v1 | `ath79/generic` |
+
+### OpenWrt / lime-packages compatibility
+
+| `openwrt_version` | Compatible `lime_ref` |
+|---|---|
+| `23.05.5` | `v2024.1` |
+| `24.10.5` | `master` or newer tags |
+| `25.12.0` | `master` or newer tags |
+
+---
+
+## What happens when you run it
+
+The workflow has three jobs that run in sequence:
+
+### 1. Resolve matrix (~5 seconds, GitHub-hosted)
+
+Parses the `duts` input and builds a job matrix so each device runs in
+parallel. For example, `"belkin_rt3200,librerouter"` becomes two independent
+build jobs.
+
+### 2. Build (~20–25 min per device, GitHub-hosted)
+
+For each device, two Docker containers run back to back:
+
+**Step 1 — OpenWrt SDK**
+Downloads `ghcr.io/openwrt/sdk:<target>-<subtarget>-v<openwrt_version>` and
+compiles the lime-packages listed below from source, using the exact git ref
+you specified in `lime_ref`. This is the slow step.
+
+Packages compiled:
+
+- `lime-system`
+- `lime-proto-babeld`
+- `lime-proto-batadv`
+- `lime-proto-anygw`
+- `lime-hwd-openwrt-wan`
+- `lime-app`
+- `shared-state` + `shared-state-babeld_hosts` + `shared-state-bat_hosts` + `shared-state-nodes_and_links`
+- `babeld-auto-gw-mode`
+- anything you add via `extra_packages`
+
+**Step 2 — OpenWrt ImageBuilder**
+Downloads `ghcr.io/openwrt/imagebuilder:<target>-<subtarget>-v<openwrt_version>`
+and assembles the compiled `.ipk` packages into a complete firmware image
+(`.bin` or `.itb`). This step takes ~2–3 minutes.
+
+The firmware is uploaded as a GitHub Actions artifact named
+`firmware-<dut>-<lime_ref>-<short_sha>` and kept for 7 days.
+
+### 3. Flash and test (lab self-hosted runner, `testbed-fcefyn`)
+
+Runs on the physical T430 machine in the FCEFYN lab.
+
+1. Downloads the firmware artifact from step 2
+2. Reserves the target device via [labgrid](https://labgrid.readthedocs.io)
+   (waits if the device is busy)
+3. Loads the firmware onto the device
+4. Runs the [libremesh-tests](https://github.com/fcefyn-testbed/libremesh-tests)
+   test suite with pytest
+5. Releases the device when done (even if tests fail)
+
+---
+
+## Examples
+
+**Test the latest stable lime-packages on the Belkin RT3200:**
+```
+duts: belkin_rt3200
+lime_ref: v2024.1
+openwrt_version: 23.05.5
+```
+
+**Test a feature branch on all devices:**
+```
+duts: all
+lime_ref: my-feature-branch
+openwrt_version: 24.10.5
+```
+
+**Add a package and remove another:**
+```
+duts: belkin_rt3200
+lime_ref: v2024.1
+extra_packages: luci-app-dawn -lime-proto-batadv
+```
+
+**Inject a custom network config:**
+```
+duts: belkin_rt3200
+lime_ref: v2024.1
+config_file: firmware/configs/belkin_rt3200.conf
+```
+
+---
+
+## Testing the build locally with `act`
+
+[act](https://github.com/nektos/act) lets you run the build job on your own
+machine without pushing to GitHub. Only the `build` job works locally — the
+`flash_and_test` job requires physical lab hardware and is automatically
+skipped.
+
+```bash
+act workflow_dispatch \
+  --workflows .github/workflows/build-and-test-libremesh.yml \
+  --job build \
+  --input duts="belkin_rt3200" \
+  --input lime_ref="v2024.1" \
+  --input openwrt_version="23.05.5" \
+  --input config_file="" \
+  --input extra_packages="" \
+  -P ubuntu-latest=catthehacker/ubuntu:act-22.04 \
+  --artifact-server-path /tmp/act-artifacts
+```
+
+The firmware is saved to `/tmp/act-artifacts` and to `./images/` in the repo
+root (not committed).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Adding a DUT: operar/dut-onboarding.md
       - Belkin U-Boot TFTP — PC Ethernet IP: operar/belkin-uboot-tftp-pc-network.md
       - Build firmware: operar/build-firmware-manual.md
+      - "CI: Build & Test": operar/ci-build-and-test.md
       - Wake-on-LAN: operar/wake-on-lan-setup.md
       - ZeroTier (admin-only): operar/zerotier-remote-access.md
   - Component configuration:


### PR DESCRIPTION
## Summary

- Adds a new section to the demos page describing the LibreMesh CI/CD workflow
- Embeds the YouTube demo video (P8dggBEgez8)
- Explains the two-stage pipeline: QEMU virtual machines on PR, physical HIL testbed after merge