### PR TITLE
docs: document scripts, Ansible roles, and lime-packages CI gate

### DIFF
--- a/docs/configuracion/ansible-roles.md
+++ b/docs/configuracion/ansible-roles.md
@@ -1,0 +1,137 @@
+# Ansible roles reference
+
+`ansible/playbook_testbed.yml` installs components that complement the
+upstream `playbook_labgrid.yml`. Each role maps to a tag so it can be run
+independently.
+
+---
+
+## Quick reference
+
+| Role | Tag | Function | Pre-requisite | Post-check |
+|------|-----|----------|--------------|------------|
+| `virtual_mesh` | `virtual_mesh` | Builds vwifi from source, installs QEMU, loads `mac80211_hwsim` | CMake, git, kernel headers | `which vwifi-server`, `lsmod | grep mac80211_hwsim` |
+| `arduino_relay` | `arduino` | Deploys arduino daemon, udev rule for `/dev/arduino-relay`, systemd service | Arduino Nano connected | `systemctl status arduino-relay-daemon` |
+| `poe_switch` | `poe_switch` | Installs `labgrid-switch-abstraction` via pipx, deploys `poe_switch_control.py` | Switch reachable via SSH | `poe_switch_control.py status 1` |
+| `wireguard` | `wireguard` | Configures WireGuard tunnel to openwrt-tests global-coordinator | Public key shared with coordinator maintainer | `wg show` |
+| `zerotier` | `zerotier` (via `testbed`) | Installs ZeroTier and joins network `93afae5963ea9881` | Node authorized at my.zerotier.com | `zerotier-cli info` |
+| `wol` | `wol` | Enables Wake-on-LAN on the host NIC at boot via systemd | Correct interface in `wol_interface` | `ethtool enp0s25 | grep Wake` |
+| `tftp_cleanup` | `tftp_cleanup` | Systemd timer that prunes broken TFTP symlinks and orphan labgrid cache dirs | TFTP dir at `/srv/tftp` | `systemctl status tftp-cleanup.timer` |
+| `observability` | `observability` | Prometheus node-exporter, autossh tunnels per DUT, Grafana dashboards | DUTs reachable, Oracle VPS configured | `curl localhost:9100/metrics` |
+
+---
+
+## Running the playbook
+
+```bash
+# Full testbed provisioning
+ansible-playbook -i ansible/inventory/hosts.yml ansible/playbook_testbed.yml -K
+
+# Single role by tag
+ansible-playbook -i ansible/inventory/hosts.yml ansible/playbook_testbed.yml \
+    --tags virtual_mesh -K
+```
+
+`-K` / `--ask-become-pass` is required because most roles install system packages
+and manage systemd units.
+
+---
+
+## Role details
+
+### `virtual_mesh`
+
+Installs the QEMU + vwifi stack required for virtual mesh tests:
+
+- Clones and builds [vwifi](https://github.com/Raizo62/vwifi) with CMake
+- Installs `qemu-system-x86`, `qemu-system-arm`
+- Loads `mac80211_hwsim` at boot (via `/etc/modules-load.d/`)
+
+Key variable: none (no defaults file; package names are hardcoded for Ubuntu).
+
+### `arduino_relay`
+
+- Deploys `scripts/arduino/arduino_daemon.py` to `/usr/local/bin/`
+- Installs `configs/templates/arduino-relay-daemon.service` to systemd
+- Writes a udev rule that creates `/dev/arduino-relay` symlink for the
+  Arduino Nano's USB-serial adapter (matched by USB vendor/product ID)
+- Enables and starts the daemon
+
+See [Arduino relay](arduino-relay.md) for the channel map and CLI reference.
+
+### `poe_switch`
+
+- Installs `labgrid-switch-abstraction` via `pipx`
+- Copies `scripts/switch/poe_switch_control.py` to `/usr/local/bin/`
+- Creates `~/.config/switch.conf` from the `switch_password` variable
+  (set in `ansible/inventory/group_vars/all.yml` or passed via `--extra-vars`)
+
+See [PoE switch control](poe-switch-control.md) for usage and troubleshooting.
+
+### `wireguard`
+
+- Generates a WireGuard key pair on the host if one does not exist
+- Renders `/etc/wireguard/wg0.conf` from a template with coordinator peer settings
+- Enables `wg-quick@wg0` at boot
+
+The lab's public key must be shared with the coordinator maintainer (Aparcar)
+to be authorized in the coordinator's `wg0.conf`. See
+[openwrt-tests onboarding](openwrt-tests-onboarding.md).
+
+### `zerotier`
+
+- Runs the official ZeroTier install script
+- Joins network `93afae5963ea9881` (admin-only remote access)
+- Node must be authorized manually at [my.zerotier.com](https://my.zerotier.com)
+
+See [ZeroTier remote access](../operar/zerotier-remote-access.md).
+
+### `wol`
+
+- Sets `WakeOnLan=magic` on `wol_interface` (default: `enp0s25`) via
+  a systemd network drop-in
+- Verifies with `ethtool` that the NIC actually supports magic-packet WoL
+
+The interface must match the host hardware. For the FCEFyN Lenovo T430
+the interface is `enp0s25`.
+
+See [Wake-on-LAN setup](../operar/wake-on-lan-setup.md).
+
+### `tftp_cleanup`
+
+Systemd timer that runs daily and removes:
+
+- **Broken symlinks** under `tftp_cleanup_tftp_dir` (`/srv/tftp`)
+- **Orphan labgrid cache dirs** under `tftp_cleanup_cache_dir`
+  (`/var/cache/labgrid`) — directories with no referencing symlink and
+  older than `tftp_cleanup_retention_days` days (default 30)
+
+Key defaults (`ansible/roles/tftp_cleanup/defaults/main.yml`):
+
+```yaml
+tftp_cleanup_tftp_dir: /srv/tftp
+tftp_cleanup_cache_dir: /var/cache/labgrid
+tftp_cleanup_retention_days: 30
+tftp_cleanup_schedule: "daily"
+tftp_cleanup_dry_run: false
+```
+
+Set `tftp_cleanup_dry_run: true` to validate on a fresh host before
+enabling real deletions.
+
+### `observability`
+
+- Installs and starts `prometheus-node-exporter` on the orchestration host
+- Creates `autossh` systemd units that maintain reverse SSH tunnels from
+  each DUT to a local port (19100–19105) for metrics scraping
+- Deploys Grafana dashboard provisioning files
+
+See [Observability](observabilidad.md) for the full monitoring stack.
+
+---
+
+## See also
+
+- [Ansible / Labgrid](ansible-labgrid.md) — upstream `playbook_labgrid.yml`
+  (exporter, places, SSH keys)
+- `ansible/playbook_testbed.yml` — playbook source with per-role tag comments

--- a/docs/configuracion/arduino-relay.md
+++ b/docs/configuracion/arduino-relay.md
@@ -187,3 +187,69 @@ arduino_relay_control.py status
 ```bash
 readlink -f /dev/arduino-relay
 ```
+
+---
+
+## 9. Full CLI reference (`arduino_relay_control.py`)
+
+```bash
+# Turn channels on/off (multiple channels allowed)
+arduino_relay_control.py on  0 1 2    # channels 0, 1, 2 on
+arduino_relay_control.py off 0        # channel 0 off
+arduino_relay_control.py toggle 0     # flip current state
+
+# Power-cycle with configurable delay (default 1000 ms)
+arduino_relay_control.py cycle 0
+arduino_relay_control.py cycle 0 --delay 2000
+
+# Pulse: turn on for N ms then off
+arduino_relay_control.py pulse 0 3000
+
+# All relays off
+arduino_relay_control.py all-off
+
+# Query current state
+arduino_relay_control.py status
+arduino_relay_control.py status 0     # single channel
+
+# GL.iNet MT300N-v2 power sequence (disconnect serial before powering on)
+arduino_relay_control.py on 0 --glinet-sequence
+```
+
+### Channel quick reference
+
+| Channel | Hardware | Notes |
+|---------|----------|-------|
+| 0 | Belkin RT3200 #1 | Electromechanical relay, 12 V DC |
+| 1 | Belkin RT3200 #2 | |
+| 2 | Belkin RT3200 #3 | |
+| 3 | Banana Pi R4 | |
+| 4 | LibreRouter 1 | 12 V DC jack (via splitter) |
+| 5–7 | Reserved / spare relays | |
+| 8 | Switch (no-load, unused) | SSR / Fotek |
+| 9 | Cooler | SSR / Fotek |
+| 10 | PSU (Fuente 12 V) | SSR / Fotek — auto-on when any DUT relay is activated |
+
+### Lock serialization
+
+`arduino_relay_control.py` uses `fcntl.flock` on `/tmp/switch.lock` to
+serialize access when multiple callers (PDUDaemon workers, manual commands)
+run concurrently. The lock is released after each command completes.
+
+---
+
+## 10. PDUDaemon integration
+
+The Ansible role configures PDUDaemon with a `localcmdline` driver that
+delegates to `arduino_relay_control.py`:
+
+```ini
+[arduino-relay]
+driver = localcmdline
+cmd_on  = arduino_relay_control.py on %s
+cmd_off = arduino_relay_control.py off %s
+cmd_status = arduino_relay_control.py status %s
+```
+
+Labgrid uses PDUDaemon to power DUTs on/off via the `PDUDaemonPower` resource
+defined in `targets/<device>.yaml`.

--- a/docs/configuracion/poe-switch-control.md
+++ b/docs/configuracion/poe-switch-control.md
@@ -1,0 +1,108 @@
+# PoE switch control (`poe_switch_control.py`)
+
+`scripts/switch/poe_switch_control.py` manages PoE power on individual ports
+of the TP-Link SG2016P managed switch. It is the backend used by PDUDaemon
+to power OpenWrt One (port 1) and LibreRouter 1 (port 2) — devices that
+receive power over Ethernet rather than via the Arduino relay board.
+
+---
+
+## 1. PoE port map
+
+Ports 1–8 on the SG2016P support PoE. Only ports in active use:
+
+| Switch port | DUT | Power mode | Notes |
+|-------------|-----|------------|-------|
+| 1 | OpenWrt One | PoE (802.3at) | Native PoE — direct |
+| 2 | LibreRouter 1 | PoE via 48 V→12 V splitter | Active-to-passive conversion; see [switch config](switch-config.md) |
+
+---
+
+## 2. Usage
+
+```bash
+# Turn PoE on/off for a single port
+poe_switch_control.py on  1
+poe_switch_control.py off 1
+
+# Power-cycle (off → sleep → on, default delay 3 s)
+poe_switch_control.py cycle 1
+poe_switch_control.py cycle 1 --delay 5
+
+# Multiple ports at once
+poe_switch_control.py on 1 2
+```
+
+---
+
+## 3. Authentication
+
+The script uses `SwitchClient` from `labgrid-switch-abstraction` for SSH.
+Credentials are loaded in order:
+
+1. `SWITCH_PASSWORD` environment variable
+2. `~/.config/switch.conf` (INI format):
+
+```ini
+[switch]
+host     = 192.168.0.1
+user     = admin
+password = <your-password>
+```
+
+The switch does not accept SSH public keys; password auth is required.
+See [switch config](switch-config.md#ssh-access) for the SSH alias setup.
+
+---
+
+## 4. Lock serialization
+
+Multiple PDUDaemon workers or manual invocations can run concurrently.
+The script uses `fcntl.flock` on `/tmp/switch.lock` to serialize SSH
+sessions and prevent contention on the switch's SSH daemon
+(which handles only one session at a time reliably).
+
+---
+
+## 5. PDUDaemon integration
+
+The Ansible role configures PDUDaemon with a `localcmdline` driver:
+
+```ini
+[poe-switch]
+driver  = localcmdline
+cmd_on  = poe_switch_control.py on %s
+cmd_off = poe_switch_control.py off %s
+cmd_status = poe_switch_control.py status %s
+```
+
+Labgrid target files reference this PDUDaemon entry via the
+`PDUDaemonPower` resource:
+
+```yaml
+resources:
+  PDUDaemonPower:
+    host: localhost
+    pdu: poe-switch
+    index: 1    # switch port number
+```
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `Authentication failed` | Wrong password | Check `SWITCH_PASSWORD` or `~/.config/switch.conf` |
+| `Connection refused` | Switch SSH not enabled or wrong IP | Verify `ssh switch-fcefyn` works manually |
+| `Invalid PoE port` | Port number > 8 or non-integer | Only ports 1–8 support PoE on SG2016P |
+| PoE on command succeeds but DUT stays off | Splitter issue (port 2 / LibreRouter) | Check 48 V→12 V splitter connection |
+| Lock timeout | Another process holding `/tmp/switch.lock` | `rm /tmp/switch.lock` if the process is gone |
+
+---
+
+## See also
+
+- [Switch configuration](switch-config.md) — VLAN setup and physical port layout
+- [Arduino relay](arduino-relay.md) — non-PoE DUT power control
+- [Adding a DUT](dut-onboarding.md) — how to register a new PoE DUT

--- a/docs/diseno/lime-packages-add-device.md
+++ b/docs/diseno/lime-packages-add-device.md
@@ -142,26 +142,15 @@ For most boards, copy an existing similar entry and adjust. Examples:
   test_qemu: true
 ```
 
-### Small-flash device
+### Small-flash / ath79 device
 
-```yaml
-- device: librerouter-v1
-  imagebuilder: ath79-generic
-  profile: librerouter_librerouter-v1
-  arch: mips_24kc
-  sdk_arch: mips_24kc-openwrt-24.10
-  index_imagebuilder: ath79-generic
-  build_initramfs: true
-  image_format: multi-uimage
-  fit_arch: mips
-  fit_kernel_loadaddr: "0x80060000"
-  fit_bootargs: "console=ttyS0,115200n8 root=/dev/ram0"
-  packages: >-
-    lime-system lime-proto-batadv lime-proto-anygw
-    lime-hwd-openwrt-wan lime-hwd-ground-routing lime-app
-    babeld-auto-gw-mode batctl-default
-    -dnsmasq -odhcpd-ipv6only
-```
+!!! warning "ath79 (LibreRouter v1) — not supported in CI"
+    This device type cannot be added to the CI matrix with the current toolchain.
+    ImageBuilder for ath79/generic does not produce a RAM-bootable `KERNEL_INITRAMFS` artifact,
+    and the LibreRouter U-Boot fork does not propagate the initrd sub-image to the kernel.
+    The `multi-uimage` path was prototyped and discarded. LibreRouter lab runs must be done
+    manually with a pre-staged firmware image.
+    See [ImageBuilder limits](lime-packages/imagebuilder-limits.md) for the full investigation.
 
 ---
 

--- a/docs/diseno/lime-packages-ci-flow.md
+++ b/docs/diseno/lime-packages-ci-flow.md
@@ -144,8 +144,13 @@ References:
 | `image_format`  | Used by                            | Artifact                                    |
 |-----------------|------------------------------------|---------------------------------------------|
 | `fit`           | mediatek-filogic, mediatek-mt7622  | `*-initramfs-libremesh.itb` (FIT)           |
-| `multi-uimage`  | ath79 (LibreRouter v1)             | `*-initramfs-libremesh.uimage` (legacy IH_TYPE_MULTI) |
 | `x86-combined`  | qemu_x86_64                        | `*-ext4-combined.img` (GRUB + kernel + ext4) |
+
+!!! note "ath79 / LibreRouter v1 — not in the CI matrix"
+    The `multi-uimage` format was prototyped for ath79 (LibreRouter v1) but removed from `targets.yml`.
+    ImageBuilder for ath79/generic does not emit a `KERNEL_INITRAMFS` artifact, and the LibreRouter U-Boot fork does not propagate the initrd sub-image to the kernel.
+    The only viable path is a full source build (~50–60 min cold), which was discarded as a CI blocker.
+    See [ImageBuilder limits](lime-packages/imagebuilder-limits.md) for the full investigation.
 
 `BUILD_INITRAMFS=1` repacks the ImageBuilder rootfs into a RAM-bootable
 artifact (`kernel-bin` + DTB + CPIO ramdisk). Targets with

--- a/docs/diseno/lime-packages/trusted-author-gate.md
+++ b/docs/diseno/lime-packages/trusted-author-gate.md
@@ -1,0 +1,119 @@
+# Trusted-author gate for physical-lab CI jobs
+
+lime-packages CI runs two classes of jobs: **virtual** (QEMU, GitHub-hosted, always safe)
+and **physical** (flashes and tests real hardware in the FCEFyN lab rack).
+Physical jobs are gated so that random pull requests from external contributors
+cannot consume lab hardware or trigger firmware flashes without human review.
+
+---
+
+## 1. Why a gate?
+
+The lab exporter publishes live hardware over WireGuard to the upstream
+openwrt-tests coordinator. Any CI job that acquires a labgrid place can:
+
+- Power-cycle a DUT via PDUDaemon
+- Write firmware over TFTP and reboot
+- Run test suites that hold the place for several minutes
+
+Allowing this for every pull request from any contributor would make the lab
+unavailable for legitimate work and could leave hardware in a bad state if a
+PR contains a broken workflow.
+
+---
+
+## 2. Mechanism: `check-trusted-author.yml`
+
+A reusable workflow (`.github/workflows/check-trusted-author.yml`) exposes a
+single boolean output: `trusted`. It is called from `build-firmware.yml` before
+any physical-lab job is dispatched.
+
+```mermaid
+flowchart TD
+    PR[Pull request opened] --> CTA[check-trusted-author.yml]
+    CTA -->|schedule event| T1[trusted = true]
+    CTA -->|workflow_dispatch| T2[trusted = false]
+    CTA -->|PR: MEMBER or OWNER| T3[trusted = true]
+    CTA -->|PR: other association| Org{Public member\nof libremesh org?}
+    Org -->|yes| T4[trusted = true]
+    Org -->|no| T5[trusted = false]
+    T1 & T3 & T4 --> Lab[Physical-lab jobs run]
+    T2 & T5 --> Skip[Physical-lab jobs skipped]
+```
+
+### Trust rules
+
+| Event | Condition | `trusted` |
+|-------|-----------|-----------|
+| `schedule` (daily cron) | — | `true` |
+| `workflow_dispatch` | — | `false` (manual runs skip physical lab) |
+| `pull_request` | `author_association` is `MEMBER` or `OWNER` of `fcefyn-testbed` | `true` |
+| `pull_request` | Author is a public member of the `libremesh` GitHub org | `true` |
+| `pull_request` | Any other contributor | `false` |
+
+### workflow_dispatch and physical jobs
+
+`workflow_dispatch` intentionally returns `trusted = false`. Physical hardware
+jobs (single-node flash, mesh test) are available as explicit inputs to
+`build-firmware.yml` (`physical_single`, `physical_mesh_count`) and run
+unconditionally when triggered manually — they do not go through the trust gate.
+The gate only prevents *unattended* physical runs on PRs.
+
+---
+
+## 3. Integration in `build-firmware.yml`
+
+`build-firmware.yml` calls `check-trusted-author.yml` as the first job and
+threads the output through subsequent jobs:
+
+```yaml
+jobs:
+  check-trusted:
+    uses: ./.github/workflows/check-trusted-author.yml
+
+  test-firmware:
+    needs: [prepare-matrix, check-trusted]
+    if: needs.check-trusted.outputs.trusted == 'true'
+    ...
+
+  test-mesh:
+    needs: [prepare-matrix, check-trusted]
+    if: needs.check-trusted.outputs.trusted == 'true'
+    ...
+```
+
+Virtual jobs (`build-firmware`, `test-qemu`, `prepare-matrix`) are unaffected
+by the trust output and always run.
+
+---
+
+## 4. Becoming a trusted contributor
+
+To have pull requests run physical-lab jobs unattended:
+
+1. Become a **public member** of the [`fcefyn-testbed` GitHub org](https://github.com/fcefyn-testbed)
+   (contact a maintainer: @francoriba, @ccasanueva7, @javierbrk), **or**
+2. Become a **public member** of the [`libremesh` GitHub org](https://github.com/libremesh).
+
+External contributors can still test their changes by asking a maintainer to
+trigger a `workflow_dispatch` run with the physical options enabled.
+
+---
+
+## 5. Security considerations
+
+- The gate uses `author_association` from the pull-request payload, which is
+  set by GitHub and cannot be spoofed by the PR author.
+- The org-membership check calls the GitHub REST API with the workflow's
+  `GITHUB_TOKEN`; only *public* org membership is checked (no token scope
+  needed beyond the default).
+- `workflow_dispatch` physical runs require the dispatcher to have write
+  access to the repository, so they are already implicitly trusted.
+
+---
+
+## See also
+
+- `.github/workflows/check-trusted-author.yml` — reusable workflow source
+- `.github/workflows/build-firmware.yml` — top-level CI orchestrator
+- [lime-packages CI: build](../lime-packages-ci-flow.md) — overall build pipeline

--- a/docs/operar/dut-gateway.md
+++ b/docs/operar/dut-gateway.md
@@ -1,0 +1,108 @@
+# DUT gateway management (`dut_gateway.py`)
+
+`scripts/switch/dut_gateway.py` updates the default gateway and DNS on all
+physical DUTs over parallel SSH immediately after a VLAN switch. It is called
+automatically by the `labgrid-switch-abstraction` library when `switch-vlan`
+changes the network mode — operators normally do not invoke it directly.
+
+---
+
+## 1. Why a separate gateway step?
+
+When a DUT moves between VLANs its upstream router changes:
+
+| Mode | VLAN | Gateway | DNS |
+|------|------|---------|-----|
+| **Isolated** (OpenWrt tests) | 100–105 per DUT | `192.168.<vlan>.254` (per-VLAN gateway) | same |
+| **Mesh** (LibreMesh tests) | 200 | `192.168.200.254` (`MESH_GATEWAY`) | `192.168.200.254` |
+
+A simple VLAN change on the switch port is not enough: OpenWrt keeps the old
+default route in memory. `dut_gateway.py` pushes a shell script to each DUT
+that:
+
+1. Persists the new gateway and DNS in UCI (`uci set network.lan.gateway`, `uci commit`)
+2. Applies the route instantly with `ip route replace default via <gw>` (no reboot needed)
+3. Ensures a source IP in the gateway subnet exists on `br-lan` so the gateway
+   can route replies back to the DUT
+
+---
+
+## 2. How it is called
+
+The function `update_dut_gateways(mode, ...)` is called by
+`switch_abstraction` after every VLAN transition:
+
+```python
+from switch.dut_gateway import update_dut_gateways
+
+update_dut_gateways(
+    mode="mesh",           # "mesh" or "isolated"
+    config_path=Path("configs/dut-config.yaml"),
+    settle_seconds=5,      # wait for VLAN propagation before SSH
+)
+```
+
+The `settle_seconds` delay (default 5 s) absorbs the time for the managed
+switch to apply the VLAN change before SSH connections are attempted.
+
+---
+
+## 3. Shell script pushed to each DUT
+
+For **mesh mode** (`MESH_GATEWAY = 192.168.200.254`):
+
+```sh
+uci delete network.lan.gateway 2>/dev/null; true
+uci set network.lan.gateway='192.168.200.254'
+uci set network.lan.dns='192.168.200.254'
+uci commit network
+ip route replace default via 192.168.200.254 dev br-lan src 10.13.200.11
+```
+
+For **isolated mode** (e.g. DUT on VLAN 100):
+
+```sh
+uci delete network.lan.gateway 2>/dev/null; true
+uci set network.lan.gateway='192.168.100.254'
+uci set network.lan.dns='192.168.100.254'
+uci commit network
+ip route replace default via 192.168.100.254 dev br-lan src 10.13.200.11
+```
+
+---
+
+## 4. Parallel SSH execution
+
+All DUTs are updated in parallel using `subprocess` with a 10-second
+SSH timeout. SSH options used:
+
+```
+-o StrictHostKeyChecking=no
+-o UserKnownHostsFile=/dev/null
+-o ConnectTimeout=10
+-o LogLevel=ERROR
+```
+
+Each DUT is identified by its `ssh_alias` field from `dut-config.yaml`
+(e.g. `dut-belkin-1`). See [SSH access to DUTs](dut-ssh-access.md) for
+how aliases are configured.
+
+---
+
+## 5. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| SSH timeout on one DUT | DUT still in isolated VLAN, SSH not reachable yet | Increase `settle_seconds` or check switch VLAN assignment |
+| `Connection refused` | DUT powered off or sshd not running | Power on DUT, check serial console |
+| Gateway not applied after SSH succeeds | Script ran but UCI/route failed | SSH into DUT manually, check `logread`, re-run `switch-vlan` |
+| All DUTs fail immediately | `dut-config.yaml` not found or `ssh_alias` missing | Verify `configs/dut-config.yaml` and DUT entries |
+
+---
+
+## See also
+
+- [Mesh IP provisioning](provision-mesh-ip.md) — one-time setup of mesh IPs via serial
+- [Unified pool architecture](../diseno/unified-pool.md) — dynamic VLAN model
+- `scripts/switch/dut_gateway.py` — source
+- `configs/dut-config.yaml` — DUT ssh_alias and VLAN mapping

--- a/docs/operar/labgrid-scripts.md
+++ b/docs/operar/labgrid-scripts.md
@@ -1,0 +1,104 @@
+# Labgrid helper scripts
+
+Two utility scripts assist with coordinator configuration and target file
+resolution. Both are optional — normal pytest runs handle these automatically
+via `LG_PLACE` and `LG_ENV` — but they are useful for debugging and manual
+setup.
+
+---
+
+## `generate_places_yaml.py`
+
+Renders `places.yaml` for the labgrid-coordinator from `labnet.yaml` and a
+Jinja2 template. Run after any change to the lab's device list or DUT
+configuration.
+
+### Usage
+
+```bash
+# Default: generate for labgrid-fcefyn, output to coordinator path
+python3 scripts/generate_places_yaml.py
+
+# Specify a different lab entry from labnet.yaml
+python3 scripts/generate_places_yaml.py --lab labgrid-hsn
+
+# Custom paths
+python3 scripts/generate_places_yaml.py \
+    --labnet /path/to/labnet.yaml \
+    --output ~/labgrid-coordinator/places.yaml
+```
+
+### How it finds `labnet.yaml`
+
+The script searches in order:
+
+1. `--labnet` CLI argument (explicit path)
+2. `$OPENWRT_TESTS_DIR/labnet.yaml`
+3. Sibling clone: `../openwrt-tests/labnet.yaml` (relative to repo root)
+4. `~/openwrt-tests/labnet.yaml`
+
+### When to regenerate
+
+- After adding or removing a DUT from `labnet.yaml`
+- After changing place names, resources, or device instances
+- After any `labnet.yaml` update that affects the `labgrid-fcefyn` entry
+
+!!! tip "Coordinator reload"
+    After regenerating, restart the labgrid-coordinator so it picks up the
+    new places: `sudo systemctl restart labgrid-coordinator`.
+
+---
+
+## `resolve_target.py`
+
+Maps a device instance name (as registered in `labnet.yaml`) to the
+labgrid target YAML file that Labgrid needs to configure resources.
+
+!!! note "Usually not needed"
+    When running pytest with `LG_PLACE` set, Labgrid resolves `LG_ENV`
+    automatically from the coordinator. Use this script only for debugging
+    or manual environment setup outside pytest.
+
+### Usage
+
+```bash
+# Find which target file corresponds to a device instance
+python3 scripts/resolve_target.py belkin_rt3200_1
+# Output: targets/linksys_e8450.yaml
+
+python3 scripts/resolve_target.py librerouter_1
+# Output: targets/librerouter_librerouter-v1.yaml
+```
+
+### How it finds `labnet.yaml`
+
+Same search order as `generate_places_yaml.py`:
+`$LABNET_PATH` → `$OPENWRT_TESTS_DIR/labnet.yaml` → sibling clone.
+
+### Mapping logic
+
+```
+device_instance (e.g. belkin_rt3200_1)
+  └─► labnet.yaml device_instances → device_type (e.g. linksys_e8450)
+        └─► targets/<device_type>.yaml
+```
+
+The mapping uses the `device_instances` section of the lab entry in
+`labnet.yaml`. If an instance is not found, the script exits with an error
+and a list of known instances.
+
+### Troubleshooting
+
+| Error | Fix |
+|-------|-----|
+| `labnet.yaml not found` | Set `LABNET_PATH` or `OPENWRT_TESTS_DIR`, or ensure `../openwrt-tests/` exists as sibling clone |
+| `Unknown device instance` | Check `labnet.yaml` `device_instances` for the `labgrid-fcefyn` entry |
+| `targets/<type>.yaml not found` | The device type is in labnet but the target file is missing from `openwrt-tests/targets/` |
+
+---
+
+## See also
+
+- [Running tests](lab-running-tests.md) — how `LG_PLACE`, `LG_ENV`, `LG_IMAGE` work together
+- [Ansible / Labgrid](../configuracion/ansible-labgrid.md) — generating `places.yaml` via Ansible
+- `openwrt-tests/labnet.yaml` — device instances and lab registration

--- a/docs/operar/provision-mesh-ip.md
+++ b/docs/operar/provision-mesh-ip.md
@@ -1,0 +1,112 @@
+# Mesh IP provisioning (`provision_mesh_ip.py`)
+
+One-time setup script that configures each physical DUT with the addresses
+needed for SSH access and test control in mesh mode (VLAN 200). Run once
+after a DUT is factory-reset or reflashed with a clean OpenWrt image.
+
+---
+
+## 1. What it configures
+
+The script connects to the DUT over **USB serial** (no network access needed)
+and applies the following via UCI:
+
+| UCI section | Interface | Address | Purpose |
+|-------------|-----------|---------|---------|
+| `network.lan_mesh` | `br-lan` | `10.13.200.x/24` | Mesh SSH/control IP — permanent alias |
+| `network.mesh_route` | `lan` | route `10.13.0.0/16 via 0.0.0.0` | On-link route so the host can reach any `10.13.x.x` address |
+| `network.lan` (ipaddr list) | `br-lan` | `192.168.200.x/24` | Secondary IP in the gateway subnet (MikroTik reachability in mesh) |
+
+All UCI sections use named keys, so the script is **idempotent** — re-running
+it on an already-provisioned DUT is safe.
+
+!!! note "Gateway is managed separately"
+    This script does **not** touch the default gateway. Gateway and DNS are
+    updated by `dut_gateway.py` each time the VLAN is switched between
+    isolated (OpenWrt tests) and mesh (LibreMesh tests).
+
+---
+
+## 2. IP address map
+
+Fixed IPs come from `configs/dut-config.yaml` (`libremesh_fixed_ip` field).
+Built-in fallback map:
+
+| Serial device | Mesh IP (`10.13.200.x`) |
+|---------------|------------------------|
+| `/dev/belkin-rt3200-1` | `10.13.200.11` |
+| `/dev/belkin-rt3200-2` | `10.13.200.196` |
+| `/dev/belkin-rt3200-3` | `10.13.200.118` |
+| `/dev/bpi-r4` | `10.13.200.169` |
+| `/dev/openwrt-one` | `10.13.200.120` |
+| `/dev/librerouter-1` | `10.13.200.77` |
+
+---
+
+## 3. Usage
+
+```bash
+# Single DUT (by serial device path or short name)
+python scripts/provision_mesh_ip.py --device /dev/belkin-rt3200-1
+python scripts/provision_mesh_ip.py --device belkin-rt3200-1
+
+# All DUTs listed in dut-config.yaml
+python scripts/provision_mesh_ip.py --all
+
+# Dry-run: print UCI commands without connecting to the DUT
+python scripts/provision_mesh_ip.py --device /dev/belkin-rt3200-1 --dry-run
+```
+
+**Dependencies:** `pyserial`, `pyyaml` (install via `pip install -r requirements.txt`).
+
+---
+
+## 4. When to run
+
+- After **factory reset** or clean OpenWrt flash (mesh IPs are not in the
+  upstream firmware).
+- After **replacing a DUT** with a new unit of the same type.
+- After provisioning via `playbook_labgrid.yml` if TFTP-boot tests are run
+  without a prior mesh provisioning step.
+
+!!! tip "Shortcut: provision all at once"
+    `--all` reads `configs/dut-config.yaml` and provisions every DUT that has
+    both a `serial_port` and a `libremesh_fixed_ip`. Run from the orchestration
+    host while all DUTs are powered and at the OpenWrt shell prompt.
+
+---
+
+## 5. How it works
+
+```
+Host serial port (/dev/belkin-rt3200-1, 115200 baud)
+  └─► send UCI commands one by one
+      ├─ uci set network.lan_mesh=interface
+      ├─ uci set network.lan_mesh.ipaddr='10.13.200.11'
+      ├─ uci set network.mesh_route=route ...
+      ├─ uci add_list network.lan.ipaddr='192.168.200.11/24'
+      └─ uci commit network
+```
+
+Each command is sent and the script waits for the shell prompt before
+proceeding. After the final `uci commit`, the script optionally calls
+`/etc/init.d/network restart` to apply immediately.
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `Permission denied: /dev/belkin-rt3200-1` | User not in `dialout` group | `sudo usermod -aG dialout $USER` (log out and back in) |
+| `No such file or directory: /dev/belkin-rt3200-1` | udev rule not applied or USB not connected | Check `lsusb`, re-apply `ansible --tags arduino` |
+| Script hangs after connecting | DUT not at shell prompt (in U-Boot or booting) | Wait for boot to finish, press Enter to get prompt |
+| `ERROR: pyserial required` | Missing dependency | `pip install pyserial` |
+
+---
+
+## See also
+
+- [DUT gateway management](dut-gateway.md) — updating the default gateway after VLAN switches
+- [Adding a DUT](dut-onboarding.md) — full onboarding procedure for new hardware
+- `configs/dut-config.yaml` — per-DUT serial port and mesh IP

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,9 @@ nav:
       - Adding a DUT: operar/dut-onboarding.md
       - Belkin U-Boot TFTP — PC Ethernet IP: operar/belkin-uboot-tftp-pc-network.md
       - Build firmware: operar/build-firmware-manual.md
+      - Mesh IP provisioning: operar/provision-mesh-ip.md
+      - DUT gateway management: operar/dut-gateway.md
+      - Labgrid helper scripts: operar/labgrid-scripts.md
       - Wake-on-LAN: operar/wake-on-lan-setup.md
       - ZeroTier (admin-only): operar/zerotier-remote-access.md
   - Component configuration:
@@ -101,8 +104,10 @@ nav:
           - DUTs: configuracion/duts-config.md
       - Services and automation:
           - Arduino relay: configuracion/arduino-relay.md
+          - PoE switch control: configuracion/poe-switch-control.md
           - TFTP / dnsmasq: configuracion/tftp-server.md
           - Ansible / Labgrid: configuracion/ansible-labgrid.md
+          - Ansible roles reference: configuracion/ansible-roles.md
           - CI Runner: configuracion/ci-runner.md
       - Observability:
           - Lab host stack (Prometheus and Grafana): configuracion/observabilidad.md
@@ -121,5 +126,6 @@ nav:
           - "Belkin RT3200 layout 1.0 DTB patch": diseno/lime-packages/belkin-rt3200-dtb.md
           - "ImageBuilder limits for ath79 / legacy linksys_e8450": diseno/lime-packages/imagebuilder-limits.md
           - "QEMU + vwifi virtual mesh": diseno/lime-packages/qemu-vwifi.md
+          - "Trusted-author CI gate": diseno/lime-packages/trusted-author-gate.md
       - Virtual mesh: diseno/virtual-mesh.md
   - Demos: demos.md


### PR DESCRIPTION
## Summary

- Corrige que ath79/LibreRouter v1 no está en el CI matrix — elimina la fila multi-uimage incorrecta de lime-packages-ci-flow.md y el ejemplo YAML de lime-packages-add-device.md
- Documenta el trusted-author gate para jobs de physical-lab (check-trusted-author.yml, lime-packages PR #7)
- Documenta provision_mesh_ip.py: provisioning de IPs mesh vía serial, secciones UCI, idempotencia, mapa por DUT
- Documenta dut_gateway.py: actualización de gateway por SSH paralelo tras cambios de VLAN
- Documenta generate_places_yaml.py y resolve_target.py: generación de places.yaml y resolución de target files desde labnet.yaml
- Expande arduino-relay.md con CLI completo, mapa de canales, lock serialization y PDUDaemon
- Documenta poe_switch_control.py: gestión de puertos PoE por SSH con lock y PDUDaemon
- Agrega referencia de los 8 roles Ansible de playbook_testbed.yml con tags, función, pre-requisito y post-check
- Actualiza mkdocs.yml con todas las páginas nuevas en la navegación