### PR TITLE
fix(dashboard): correct place names for BPi-R4 and OpenWrt One

### DIFF
--- a/docs/ci-results/dashboard.html
+++ b/docs/ci-results/dashboard.html
@@ -675,6 +675,11 @@
         for (const d of devices) {
           if (!byId.has(d.id)) {
             byId.set(d.id, { ...d, displayName: d.display_name || d.id, runs: [], _report: null });
+          } else if (d.display_name) {
+            // Enrich API-derived entry with friendly name and results path from registry
+            const e = byId.get(d.id);
+            e.displayName = d.display_name;
+            if (d.results_path) e.results_path = d.results_path;
           }
         }
       }

--- a/docs/ci-results/results/devices.json
+++ b/docs/ci-results/results/devices.json
@@ -29,22 +29,22 @@
       "results_path": "physical/belkin_rt3200_3-24.10.6/report.xml"
     },
     {
-      "id": "physical-bpi_r4_1-24.10.6",
+      "id": "physical-bananapi_bpi-r4-24.10.6",
       "device": "bananapi_bpi-r4",
       "display_name": "BPi-R4 #1",
-      "place": "bpi_r4_1",
+      "place": "bananapi_bpi-r4",
       "release": "24.10.6",
       "type": "physical",
-      "results_path": "physical/bpi_r4_1-24.10.6/report.xml"
+      "results_path": "physical/bananapi_bpi-r4-24.10.6/report.xml"
     },
     {
-      "id": "physical-openwrt_one_1-24.10.6",
+      "id": "physical-openwrt_one-24.10.6",
       "device": "openwrt_one",
       "display_name": "OpenWrt One #1",
-      "place": "openwrt_one_1",
+      "place": "openwrt_one",
       "release": "24.10.6",
       "type": "physical",
-      "results_path": "physical/openwrt_one_1-24.10.6/report.xml"
+      "results_path": "physical/openwrt_one-24.10.6/report.xml"
     },
     {
       "id": "qemu-single-qemu_x86_64-24.10.6",
@@ -110,22 +110,22 @@
       "results_path": "physical/belkin_rt3200_3-25.12.2/report.xml"
     },
     {
-      "id": "physical-bpi_r4_1-25.12.2",
+      "id": "physical-bananapi_bpi-r4-25.12.2",
       "device": "bananapi_bpi-r4",
       "display_name": "BPi-R4 #1",
-      "place": "bpi_r4_1",
+      "place": "bananapi_bpi-r4",
       "release": "25.12.2",
       "type": "physical",
-      "results_path": "physical/bpi_r4_1-25.12.2/report.xml"
+      "results_path": "physical/bananapi_bpi-r4-25.12.2/report.xml"
     },
     {
-      "id": "physical-openwrt_one_1-25.12.2",
+      "id": "physical-openwrt_one-25.12.2",
       "device": "openwrt_one",
       "display_name": "OpenWrt One #1",
-      "place": "openwrt_one_1",
+      "place": "openwrt_one",
       "release": "25.12.2",
       "type": "physical",
-      "results_path": "physical/openwrt_one_1-25.12.2/report.xml"
+      "results_path": "physical/openwrt_one-25.12.2/report.xml"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Fixes duplicate device cards on the dashboard
- The CI uses `bananapi_bpi-r4` and `openwrt_one` as place names in job names, but `devices.json` had `bpi_r4_1` and `openwrt_one_1` — mismatched IDs caused two cards per device
- Updated `devices.json` to match the actual CI place names
- Dashboard now also enriches API-derived entries with `display_name` from the registry when IDs match

## Test plan

- [ ] Open dashboard on Pages and verify BPi-R4 and OpenWrt One each appear as a single card with their friendly names ("BPi-R4 #1", "OpenWrt One #1")