### PR TITLE
fix(dashboard): bypass CDN cache for devices.json fetch

### DIFF
--- a/docs/ci-results/dashboard.html
+++ b/docs/ci-results/dashboard.html
@@ -669,7 +669,7 @@
     // Also load devices.json to include entries not visible in the GitHub API
     // (e.g. unit tests from tests.yml which is a separate workflow)
     try {
-      const devData = await fetch(RESULTS_BASE + 'devices.json');
+      const devData = await fetch(RESULTS_BASE + 'devices.json?v=' + Date.now(), { cache: 'no-store' });
       if (devData.ok) {
         const { devices } = await devData.json();
         for (const d of devices) {


### PR DESCRIPTION
## Summary

- Adds `cache: 'no-store'` and timestamp query param to the `devices.json` fetch
- GitHub Pages CDN was caching the old `devices.json` (with wrong place names `bpi_r4_1`, `openwrt_one_1`) even after a new deployment
- The correct place names `bananapi_bpi-r4` and `openwrt_one` are already in `develop` but the browser/CDN kept serving the stale file