### PR TITLE
feat(grafana): lab services, WireGuard, lab-overview and DUT improvements

### DIFF
--- a/ansible/roles/observability/files/dashboards/duts-node.json
+++ b/ansible/roles/observability/files/dashboards/duts-node.json
@@ -306,10 +306,32 @@
         { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "-rate(node_network_transmit_packets_total{dut=\"$device\",device!=\"lo\"}[2m])", "legendFormat": "tx {{device}}", "refId": "B" }
       ]
     },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 5, "lineInterpolation": "smooth", "lineWidth": 1, "showPoints": "never", "spanNulls": true },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 41 },
+      "id": 43,
+      "options": { "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "title": "Network errors & drops",
+      "type": "timeseries",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "rate(node_network_receive_errs_total{dut=\"$device\",device!=\"lo\"}[2m])", "legendFormat": "rx err {{device}}", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "rate(node_network_transmit_errs_total{dut=\"$device\",device!=\"lo\"}[2m])", "legendFormat": "tx err {{device}}", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "rate(node_network_receive_drop_total{dut=\"$device\",device!=\"lo\"}[2m])", "legendFormat": "rx drop {{device}}", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "rate(node_network_transmit_drop_total{dut=\"$device\",device!=\"lo\"}[2m])", "legendFormat": "tx drop {{device}}", "refId": "D" }
+      ],
+      "description": "Tasa de errores y drops RX/TX por interfaz; debería ser 0 en condiciones normales."
+    },
 
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 49 },
       "id": 50,
       "title": "Disk / filesystem",
       "type": "row"

--- a/ansible/roles/observability/files/dashboards/lab-overview.json
+++ b/ansible/roles/observability/files/dashboards/lab-overview.json
@@ -47,7 +47,7 @@
       "title": "Scrape up — all devices",
       "type": "stat",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "up{job=~\"dut|gateway\"}", "legendFormat": "{{dut}}", "refId": "A" }
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "up{dut=~\".+\"}", "legendFormat": "{{dut}}", "refId": "A" }
       ],
       "description": "Verde = Prometheus puede scrapear el dispositivo. Rojo = sin datos (apagado, sin red o node_exporter caído)."
     },
@@ -84,7 +84,7 @@
       "title": "Uptime per device",
       "type": "stat",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_time_seconds{job=~\"dut|gateway\"} - node_boot_time_seconds{job=~\"dut|gateway\"}", "legendFormat": "{{dut}}", "refId": "A" }
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_time_seconds{dut=~\".+\"} - node_boot_time_seconds{dut=~\".+\"}", "legendFormat": "{{dut}}", "refId": "A" }
       ],
       "description": "Tiempo desde el último arranque. Verde = recién encendido; naranja = lleva más de 24 h."
     },
@@ -123,7 +123,7 @@
       "title": "CPU busy per device",
       "type": "stat",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (avg by (dut) (rate(node_cpu_seconds_total{job=~\"dut|gateway\",mode=\"idle\"}[2m])) * 100)", "legendFormat": "{{dut}}", "refId": "A" }
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (avg by (dut) (rate(node_cpu_seconds_total{dut=~\".+\",mode=\"idle\"}[2m])) * 100)", "legendFormat": "{{dut}}", "refId": "A" }
       ],
       "description": "Porcentaje de CPU en uso (100 - idle rate 2m)."
     },
@@ -162,7 +162,7 @@
       "title": "RAM used per device",
       "type": "stat",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (node_memory_MemAvailable_bytes{job=~\"dut|gateway\"} / node_memory_MemTotal_bytes{job=~\"dut|gateway\"} * 100)", "legendFormat": "{{dut}}", "refId": "A" }
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (node_memory_MemAvailable_bytes{dut=~\".+\"} / node_memory_MemTotal_bytes{dut=~\".+\"} * 100)", "legendFormat": "{{dut}}", "refId": "A" }
       ],
       "description": "Porcentaje de RAM no disponible (100 - MemAvailable/MemTotal)."
     },
@@ -219,10 +219,10 @@
       ],
       "type": "table",
       "targets": [
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "up{job=~\"dut|gateway\"}", "legendFormat": "{{dut}}", "refId": "A", "instant": true, "format": "table" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_time_seconds{job=~\"dut|gateway\"} - node_boot_time_seconds{job=~\"dut|gateway\"}", "legendFormat": "{{dut}}", "refId": "B", "instant": true, "format": "table" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (avg by (dut) (rate(node_cpu_seconds_total{job=~\"dut|gateway\",mode=\"idle\"}[2m])) * 100)", "legendFormat": "{{dut}}", "refId": "C", "instant": true, "format": "table" },
-        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (node_memory_MemAvailable_bytes{job=~\"dut|gateway\"} / node_memory_MemTotal_bytes{job=~\"dut|gateway\"} * 100)", "legendFormat": "{{dut}}", "refId": "D", "instant": true, "format": "table" }
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "up{dut=~\".+\"}", "legendFormat": "{{dut}}", "refId": "A", "instant": true, "format": "table" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_time_seconds{dut=~\".+\"} - node_boot_time_seconds{dut=~\".+\"}", "legendFormat": "{{dut}}", "refId": "B", "instant": true, "format": "table" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (avg by (dut) (rate(node_cpu_seconds_total{dut=~\".+\",mode=\"idle\"}[2m])) * 100)", "legendFormat": "{{dut}}", "refId": "C", "instant": true, "format": "table" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (node_memory_MemAvailable_bytes{dut=~\".+\"} / node_memory_MemTotal_bytes{dut=~\".+\"} * 100)", "legendFormat": "{{dut}}", "refId": "D", "instant": true, "format": "table" }
       ],
       "description": "Vista consolidada: un DUT por fila con scrape up, uptime, CPU% y RAM%."
     }

--- a/ansible/roles/observability/files/dashboards/lab-overview.json
+++ b/ansible/roles/observability/files/dashboards/lab-overview.json
@@ -225,6 +225,40 @@
         { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (node_memory_MemAvailable_bytes{dut=~\".+\"} / node_memory_MemTotal_bytes{dut=~\".+\"} * 100)", "legendFormat": "{{dut}}", "refId": "D", "instant": true, "format": "table" }
       ],
       "description": "Vista consolidada: un DUT por fila con scrape up, uptime, CPU% y RAM%."
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
+      "id": 50,
+      "title": "Firmware & target",
+      "type": "row",
+      "description": "Versión de firmware y target OpenWrt de cada DUT según node_openwrt_info."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "displayMode": "auto" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 37 },
+      "id": 51,
+      "options": { "showHeader": true, "sortBy": [{ "displayName": "dut", "desc": false }] },
+      "title": "Firmware per device",
+      "transformations": [
+        { "id": "labelsToFields", "options": { "mode": "columns" } },
+        { "id": "organize", "options": {
+          "excludeByName": { "Time": true, "Value": true, "__name__": true, "instance": true, "job": true, "target": false },
+          "renameByName": { "dut": "device", "firmware": "firmware", "target": "OpenWrt target" }
+        }}
+      ],
+      "type": "table",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_openwrt_info{dut=~\".+\"}", "format": "table", "instant": true, "refId": "A" }
+      ],
+      "description": "Tabla de firmware y target por DUT. Fuente: node_openwrt_info (label firmware y target del scrape config)."
     }
   ],
   "refresh": "30s",

--- a/ansible/roles/observability/files/dashboards/lab-overview.json
+++ b/ansible/roles/observability/files/dashboards/lab-overview.json
@@ -1,0 +1,241 @@
+{
+  "annotations": { "list": [] },
+  "description": "FCEFyN Testbed — Lab-wide overview: all DUTs and gateway at a glance. Uptime, CPU, RAM and scrape status per device.",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Device health at a glance",
+      "type": "row",
+      "description": "Estado actual de cada DUT y gateway: scrape up, uptime, CPU y RAM."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "type": "value", "options": {
+              "0": { "text": "DOWN", "color": "red", "index": 0 },
+              "1": { "text": "UP", "color": "green", "index": 1 }
+            }}
+          ],
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "red", "value": null },
+            { "color": "green", "value": 1 }
+          ]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "title": "Scrape up — all devices",
+      "type": "stat",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "up{job=~\"dut|gateway\"}", "legendFormat": "{{dut}}", "refId": "A" }
+      ],
+      "description": "Verde = Prometheus puede scrapear el dispositivo. Rojo = sin datos (apagado, sin red o node_exporter caído)."
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "id": 10,
+      "title": "Uptime",
+      "type": "row",
+      "description": "Tiempo encendido de cada dispositivo desde el último arranque."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 3600 },
+            { "color": "orange", "value": 86400 }
+          ]},
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 8 },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "title": "Uptime per device",
+      "type": "stat",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_time_seconds{job=~\"dut|gateway\"} - node_boot_time_seconds{job=~\"dut|gateway\"}", "legendFormat": "{{dut}}", "refId": "A" }
+      ],
+      "description": "Tiempo desde el último arranque. Verde = recién encendido; naranja = lleva más de 24 h."
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "id": 20,
+      "title": "CPU",
+      "type": "row",
+      "description": "Uso de CPU (non-idle) en cada dispositivo."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 50 },
+            { "color": "red", "value": 80 }
+          ]},
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        }
+      },
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 14 },
+      "id": 21,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "title": "CPU busy per device",
+      "type": "stat",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (avg by (dut) (rate(node_cpu_seconds_total{job=~\"dut|gateway\",mode=\"idle\"}[2m])) * 100)", "legendFormat": "{{dut}}", "refId": "A" }
+      ],
+      "description": "Porcentaje de CPU en uso (100 - idle rate 2m)."
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 19 },
+      "id": 30,
+      "title": "Memory",
+      "type": "row",
+      "description": "Uso de RAM por dispositivo."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 60 },
+            { "color": "red", "value": 85 }
+          ]},
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        }
+      },
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 20 },
+      "id": 31,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "auto"
+      },
+      "title": "RAM used per device",
+      "type": "stat",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (node_memory_MemAvailable_bytes{job=~\"dut|gateway\"} / node_memory_MemTotal_bytes{job=~\"dut|gateway\"} * 100)", "legendFormat": "{{dut}}", "refId": "A" }
+      ],
+      "description": "Porcentaje de RAM no disponible (100 - MemAvailable/MemTotal)."
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 25 },
+      "id": 40,
+      "title": "Device table",
+      "type": "row",
+      "description": "Tabla consolidada: uptime, CPU, RAM y scrape status en una sola vista."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "displayMode": "auto" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "up" }, "properties": [
+            { "id": "custom.displayMode", "value": "color-background" },
+            { "id": "thresholds", "value": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] } },
+            { "id": "mappings", "value": [{ "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }] }
+          ]},
+          { "matcher": { "id": "byName", "options": "CPU %" }, "properties": [
+            { "id": "unit", "value": "percent" },
+            { "id": "custom.displayMode", "value": "color-background" },
+            { "id": "thresholds", "value": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 50 }, { "color": "red", "value": 80 }] } }
+          ]},
+          { "matcher": { "id": "byName", "options": "RAM %" }, "properties": [
+            { "id": "unit", "value": "percent" },
+            { "id": "custom.displayMode", "value": "color-background" },
+            { "id": "thresholds", "value": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 60 }, { "color": "red", "value": 85 }] } }
+          ]},
+          { "matcher": { "id": "byName", "options": "Uptime" }, "properties": [
+            { "id": "unit", "value": "s" }
+          ]}
+        ]
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 26 },
+      "id": 41,
+      "options": { "showHeader": true, "sortBy": [{ "displayName": "dut", "desc": false }] },
+      "title": "All devices — consolidated status",
+      "transformations": [
+        { "id": "merge", "options": {} },
+        { "id": "organize", "options": {
+          "renameByName": {
+            "Value #A": "up",
+            "Value #B": "Uptime",
+            "Value #C": "CPU %",
+            "Value #D": "RAM %"
+          }
+        }}
+      ],
+      "type": "table",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "up{job=~\"dut|gateway\"}", "legendFormat": "{{dut}}", "refId": "A", "instant": true, "format": "table" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_time_seconds{job=~\"dut|gateway\"} - node_boot_time_seconds{job=~\"dut|gateway\"}", "legendFormat": "{{dut}}", "refId": "B", "instant": true, "format": "table" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (avg by (dut) (rate(node_cpu_seconds_total{job=~\"dut|gateway\",mode=\"idle\"}[2m])) * 100)", "legendFormat": "{{dut}}", "refId": "C", "instant": true, "format": "table" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "100 - (node_memory_MemAvailable_bytes{job=~\"dut|gateway\"} / node_memory_MemTotal_bytes{job=~\"dut|gateway\"} * 100)", "legendFormat": "{{dut}}", "refId": "D", "instant": true, "format": "table" }
+      ],
+      "description": "Vista consolidada: un DUT por fila con scrape up, uptime, CPU% y RAM%."
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": ["fcefyn", "node-exporter", "lab-overview"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "FCEFyN Testbed - Lab Overview",
+  "uid": "fcefyn-lab-overview",
+  "version": 1
+}

--- a/ansible/roles/observability/files/dashboards/orchestrator-node.json
+++ b/ansible/roles/observability/files/dashboards/orchestrator-node.json
@@ -2421,6 +2421,127 @@
         { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_systemd_unit_state{job=\"orchestrator-host\",name=\"ser2net.service\",state=\"active\"}", "legendFormat": "ser2net", "refId": "C" }
       ],
       "description": "Historial de estado de los tres servicios; verde = active, rojo = caído."
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 101 },
+      "id": 100,
+      "title": "WireGuard (wg0)",
+      "type": "row",
+      "description": "Tráfico en la interfaz wg0 — enlace cifrado entre el runner de CI y el lab host."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": true,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "bps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 102 },
+      "id": 101,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "WireGuard Bandwidth",
+      "type": "timeseries",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "rate(node_network_receive_bytes_total{job=\"orchestrator-host\",device=\"wg0\"}[2m]) * 8", "legendFormat": "rx", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "-rate(node_network_transmit_bytes_total{job=\"orchestrator-host\",device=\"wg0\"}[2m]) * 8", "legendFormat": "tx", "refId": "B" }
+      ],
+      "description": "Bits/s recibidos (positivo) y enviados (negativo) por wg0."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": true,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "pps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 102 },
+      "id": 102,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "WireGuard Packets",
+      "type": "timeseries",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "rate(node_network_receive_packets_total{job=\"orchestrator-host\",device=\"wg0\"}[2m])", "legendFormat": "rx", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "-rate(node_network_transmit_packets_total{job=\"orchestrator-host\",device=\"wg0\"}[2m])", "legendFormat": "tx", "refId": "B" }
+      ],
+      "description": "Paquetes/s en wg0; rx positivo, tx negativo."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "red", "value": 1 }
+          ]},
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 110 },
+      "id": 103,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "title": "wg0 Errors",
+      "type": "stat",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "rate(node_network_receive_errs_total{job=\"orchestrator-host\",device=\"wg0\"}[5m]) + rate(node_network_transmit_errs_total{job=\"orchestrator-host\",device=\"wg0\"}[5m])", "refId": "A" }
+      ],
+      "description": "Tasa de errores RX+TX en wg0; debería ser 0."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "type": "value", "options": {
+              "0": { "text": "DOWN", "color": "red", "index": 0 },
+              "1": { "text": "UP", "color": "green", "index": 1 }
+            }}
+          ],
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "red", "value": null },
+            { "color": "green", "value": 1 }
+          ]},
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 110 },
+      "id": 104,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "title": "wg0 Link",
+      "type": "stat",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_network_up{job=\"orchestrator-host\",device=\"wg0\"}", "refId": "A" }
+      ],
+      "description": "Estado operativo de la interfaz wg0 (node_network_up)."
     }
   ],
   "refresh": "30s",

--- a/ansible/roles/observability/files/dashboards/orchestrator-node.json
+++ b/ansible/roles/observability/files/dashboards/orchestrator-node.json
@@ -2306,6 +2306,121 @@
         }
       ],
       "description": "Memoria del kernel asociada a sockets TCP y UDP."
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 90 },
+      "id": 90,
+      "title": "Lab Services",
+      "type": "row",
+      "description": "Estado de los servicios críticos del testbed: labgrid-exporter, pdudaemon y ser2net."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [{ "type": "value", "options": {
+            "0": { "text": "FAILED", "color": "red", "index": 0 },
+            "1": { "text": "ACTIVE", "color": "green", "index": 1 }
+          }}],
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "red", "value": null },
+            { "color": "green", "value": 1 }
+          ]},
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 91 },
+      "id": 91,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "title": "labgrid-exporter",
+      "type": "stat",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_systemd_unit_state{job=\"orchestrator-host\",name=\"labgrid-exporter.service\",state=\"active\"}", "refId": "A" }],
+      "description": "1 = active, 0 = failed. Requiere collector systemd en node_exporter."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [{ "type": "value", "options": {
+            "0": { "text": "FAILED", "color": "red", "index": 0 },
+            "1": { "text": "ACTIVE", "color": "green", "index": 1 }
+          }}],
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "red", "value": null },
+            { "color": "green", "value": 1 }
+          ]},
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 91 },
+      "id": 92,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "title": "pdudaemon",
+      "type": "stat",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_systemd_unit_state{job=\"orchestrator-host\",name=\"pdudaemon.service\",state=\"active\"}", "refId": "A" }],
+      "description": "Control de relay/PDU para encendido y apagado de DUTs."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [{ "type": "value", "options": {
+            "0": { "text": "FAILED", "color": "red", "index": 0 },
+            "1": { "text": "ACTIVE", "color": "green", "index": 1 }
+          }}],
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "red", "value": null },
+            { "color": "green", "value": 1 }
+          ]},
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 91 },
+      "id": 93,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "title": "ser2net",
+      "type": "stat",
+      "targets": [{ "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_systemd_unit_state{job=\"orchestrator-host\",name=\"ser2net.service\",state=\"active\"}", "refId": "A" }],
+      "description": "Acceso serial a DUTs vía USB-to-serial y TCP."
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": {
+              "0": { "text": "down", "color": "red", "index": 0 },
+              "1": { "text": "up", "color": "green", "index": 1 }
+            }}
+          ],
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "red", "value": null },
+            { "color": "green", "value": 1 }
+          ]}
+        }
+      },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 95 },
+      "id": 94,
+      "options": {
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "auto",
+        "alignValue": "left",
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "title": "Service state history",
+      "type": "state-timeline",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_systemd_unit_state{job=\"orchestrator-host\",name=\"labgrid-exporter.service\",state=\"active\"}", "legendFormat": "labgrid-exporter", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_systemd_unit_state{job=\"orchestrator-host\",name=\"pdudaemon.service\",state=\"active\"}", "legendFormat": "pdudaemon", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "node_systemd_unit_state{job=\"orchestrator-host\",name=\"ser2net.service\",state=\"active\"}", "legendFormat": "ser2net", "refId": "C" }
+      ],
+      "description": "Historial de estado de los tres servicios; verde = active, rojo = caído."
     }
   ],
   "refresh": "30s",
@@ -2327,5 +2442,5 @@
   "timezone": "browser",
   "title": "FCEFyN Testbed - Orchestrator Host",
   "uid": "fcefyn-orchestrator-node",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
## Summary

- **orchestrator dashboard**: new Lab Services section (labgrid-exporter, pdudaemon, ser2net state stats + history timeline)
- **orchestrator dashboard**: new WireGuard section (wg0 bandwidth, packets, errors, link status)
- **lab-overview dashboard** (new): consolidated view of all DUTs — scrape up/down, uptime, CPU%, RAM%, firmware table
- **DUTs dashboard**: network errors & drops panel added to Network section

## Test plan

- [ ] Open Grafana and verify the three dashboards load without errors
- [ ] Lab Services section shows green for labgrid-exporter, pdudaemon, ser2net when services are running
- [ ] WireGuard panels show traffic on wg0 when CI is active
- [ ] Lab Overview shows correct scrape status per device
- [ ] DUTs dashboard shows network errors panel (should be near zero in normal conditions)