### PR TITLE
fix(ci): use default GITHUB_TOKEN for collect-lime-results PR

### DIFF
--- a/.github/workflows/collect-lime-results.yml
+++ b/.github/workflows/collect-lime-results.yml
@@ -133,7 +133,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.TESTBED_UTILS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           base: develop
           branch: bot/lime-results
           delete-branch: true
@@ -155,7 +155,7 @@ jobs:
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.TESTBED_UTILS_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr merge --auto --squash \
             --repo "${{ github.repository }}" \


### PR DESCRIPTION
## Summary
Switches \`peter-evans/create-pull-request\` and \`gh pr merge --auto\` from \`TESTBED_UTILS_TOKEN\` (which doesn't exist in this repo) to the auto-provided \`GITHUB_TOKEN\`.

## Why
First retry of the workflow with the PR-based flow failed: "Input 'token' not supplied". \`TESTBED_UTILS_TOKEN\` is the secret in lime-packages that lets *that* repo write into this one; here we don't have it, and we don't need a PAT — the workflow already declares \`contents: write\` and \`pull-requests: write\`, which the default GITHUB_TOKEN honours.

## Test plan
- [ ] Merge
- [ ] Manually run "Collect lime-packages test results"
- [ ] Verify the bot PR is created, auto-merges, and the report.xml files appear on develop