### PR TITLE
fix(ci): use BOT_PR_TOKEN for collect-lime-results PR flow

### DIFF
--- a/.github/workflows/collect-lime-results.yml
+++ b/.github/workflows/collect-lime-results.yml
@@ -133,7 +133,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           base: develop
           branch: bot/lime-results
           delete-branch: true
@@ -155,7 +155,7 @@ jobs:
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PR_TOKEN }}
         run: |
           gh pr merge --auto --squash \
             --repo "${{ github.repository }}" \


### PR DESCRIPTION
## Summary
Swap the default \`GITHUB_TOKEN\` for the new \`BOT_PR_TOKEN\` PAT on the steps that create and auto-merge the bot PR. Checkout keeps \`GITHUB_TOKEN\`.

## Why
The org has \"Allow GitHub Actions to create and approve pull requests\" disabled, so \`GITHUB_TOKEN\` cannot open PRs or call \`gh pr merge --auto\`. We can't toggle that at the repo level. \`BOT_PR_TOKEN\` is a user PAT with Contents + Pull Requests: write on this repo only.

## Test plan
- [ ] Merge
- [ ] Manually run "Collect lime-packages test results"
- [ ] Verify bot PR is opened, auto-merges, and report.xml files appear on \`develop\`