### PR TITLE
fix(dashboard): point PAGES_BASE to fcefyn_testbed_utils Pages

### DIFF
--- a/docs/ci-results/dashboard.html
+++ b/docs/ci-results/dashboard.html
@@ -372,7 +372,7 @@
   const RESULTS_BASE = 'results/';   // served alongside this page
   // Base URL of the GitHub Pages site where test reports are published.
   // Set to empty string to disable direct report links.
-  const PAGES_BASE   = 'https://fcefyn-testbed.github.io/lime-packages/ci-results/results/';
+  const PAGES_BASE   = 'https://fcefyn-testbed.github.io/fcefyn_testbed_utils/ci-results/results/';
 
   // ── GitHub API (no auth, public repo) ─────────────────────────────────────
   async function ghFetch(path) {


### PR DESCRIPTION
Reports are published under `fcefyn-testbed.github.io/fcefyn_testbed_utils/ci-results/results/`, not `/lime-packages/`. One-line fix to stop the Report ↗ links from 404-ing.